### PR TITLE
Updated scripts to build a more updated 4.2.1 image on ubuntu 22.04

### DIFF
--- a/marketplace-image.json
+++ b/marketplace-image.json
@@ -7,7 +7,7 @@
     {
       "type": "digitalocean",
       "api_token": "{{user `token`}}",
-      "image": "ubuntu-20-04-x64",
+      "image": "ubuntu-22-04-x64",
       "region": "nyc3",
       "size": "s-1vcpu-2gb",
       "ssh_username": "root",

--- a/scripts/01-prepare.sh
+++ b/scripts/01-prepare.sh
@@ -2,20 +2,24 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
+NODE_MAJOR=20
+
 cloud-init status --wait \
-  && apt -qqy update \
-  && apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade \
-  && apt -qqy install fail2ban iptables-persistent wget gnupg apt-transport-https lsb-release ca-certificates \
-  && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+  && apt-get -qqy update \
+  && apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade \
+  && apt-get -qqy install fail2ban iptables-persistent wget curl gnupg apt-transport-https lsb-release ca-certificates \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
   && wget -O /usr/share/keyrings/postgresql.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc \
   && echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgresql.list \
-  && apt -qqy update \
-  && apt -qqy install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git-core \
+  && apt-get -qqy update \
+  && apt-get -qqy install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git-core \
     g++ libprotobuf-dev protobuf-compiler pkg-config nodejs gcc autoconf \
     bison build-essential libssl-dev libyaml-dev libreadline6-dev \
     zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev \
     nginx redis-server redis-tools postgresql postgresql-contrib \
     certbot python3-certbot-nginx libidn11-dev libicu-dev libjemalloc-dev \
+    nodejs \
   && corepack enable \
   && yarn set version stable \
   && adduser --disabled-login --gecos '' mastodon \

--- a/scripts/02-install.sh
+++ b/scripts/02-install.sh
@@ -2,18 +2,17 @@
 
 cd /home/mastodon \
   && git clone https://github.com/rbenv/rbenv.git /home/mastodon/.rbenv \
-  && cd /home/mastodon/.rbenv && src/configure && make -C src \
   && echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> /home/mastodon/.bashrc \
-  && echo 'eval "$(rbenv init -)"' >> /home/mastodon/.bashrc \
+  && echo 'eval "$(/home/mastodon/.rbenv/bin/rbenv init - bash)"' >> /home/mastodon/.bashrc \
   && export PATH="$HOME/.rbenv/bin:$PATH" \
-  && eval "$(rbenv init -)" \
+  && eval "$(rbenv init - bash)" \
   && git clone https://github.com/rbenv/ruby-build.git /home/mastodon/.rbenv/plugins/ruby-build \
-  && RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.0.3 \
-  && rbenv global 3.0.3 \
+  && RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 3.2.2 \
+  && rbenv global 3.2.2 \
   && cd /home/mastodon \
   && gem install bundler --no-document \
-  && git clone https://github.com/tootsuite/mastodon.git live && cd live \
-  && git checkout v3.5.3 \
+  && git clone https://github.com/mastodon/mastodon.git live && cd live \
+  && git checkout v4.2.1 \
   && bundle config set --local deployment 'true' \
   && bundle config set --local without 'development test' \
   && bundle install -j$(getconf _NPROCESSORS_ONLN) \

--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 rm -rf /tmp/* /var/tmp/*
 history -c
 cat /dev/null > /root/.bash_history
@@ -16,5 +18,14 @@ rm -rf /var/lib/cloud/instance
 
 rm -f /root/.ssh/authorized_keys /etc/ssh/*key*
 
-dd if=/dev/zero of=/zerofile; sync; rm /zerofile; sync
+# Securely erase the unused portion of the filesystem
+GREEN='\033[0;32m'
+NC='\033[0m'
+printf "\n${GREEN}Writing zeros to the remaining disk space to securely
+erase the unused portion of the file system.
+Depending on your disk size this may take several minutes.
+The secure erase will complete successfully when you see:${NC}
+    dd: writing to '/zerofile': No space left on device\n
+Beginning secure erase now\n"
+dd if=/dev/zero of=/zerofile bs=4096; sync; rm /zerofile; sync
 cat /dev/null > /var/log/lastlog; cat /dev/null > /var/log/wtmp; cat /dev/null > /var/log/auth.log

--- a/scripts/99-img_check.sh
+++ b/scripts/99-img_check.sh
@@ -4,7 +4,7 @@
 # © 2021-2022 DigitalOcean LLC.
 # This code is licensed under Apache 2.0 license (see LICENSE.md for details)
 
-VERSION="v. 1.8"
+VERSION="v. 1.8.1"
 RUNDATE=$( date )
 
 # Script should be run with SUDO
@@ -75,7 +75,7 @@ function checkAgent {
      echo -en "\e[41m[FAIL]\e[0m DigitalOcean directory detected.\n"
             ((FAIL++))
             STATUS=2
-      if [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
+      if [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]] || [[ $OS == "AlmaLinux" ]]; then
         echo "To uninstall the agent: 'sudo yum remove droplet-agent'"
         echo "To remove the DO directory: 'find /opt/digitalocean/ -type d -empty -delete'"
       elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]]; then
@@ -357,7 +357,7 @@ function checkFirewall {
         # shellcheck disable=SC2031
         ((WARN++))
       fi
-    elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
+    elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]] || [[ $OS == "AlmaLinux" ]]; then
       if [ -f /usr/lib/systemd/system/csf.service ]; then
         fw="csf"
         if [[ $(systemctl status $fw >/dev/null 2>&1) ]]; then
@@ -456,7 +456,7 @@ function checkUpdates {
             echo -en "\e[32m[PASS]\e[0m There are no pending security updates for this image.\n\n"
             ((PASS++))
         fi
-    elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
+    elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]] || [[ $OS == "AlmaLinux" ]]; then
         echo -en "\nChecking for available security updates, this may take a minute...\n\n"
 
         update_count=$(yum check-update --security --quiet | wc -l)
@@ -506,7 +506,7 @@ osv=0
 
 if [[ $OS == "Ubuntu" ]]; then
         ost=1
-    if [[ $VER == "22.04" ]] || [[ $VER == "20.04" ]] || [[ $VER == "18.04" ]] || [[ $VER == "16.04" ]]; then
+    if [[ $VER == "22.10" ]] || [[ $VER == "22.04" ]] || [[ $VER == "20.04" ]] || [[ $VER == "18.04" ]] || [[ $VER == "16.04" ]]; then
         osv=1
     fi
 
@@ -521,7 +521,10 @@ elif [[ "$OS" =~ Debian.* ]]; then
             ;;
         11)
             osv=1
-            ;;            
+            ;;
+        12)
+            osv=1
+            ;;
         *)
             osv=2
             ;;
@@ -542,12 +545,21 @@ elif [[ $OS == "CentOS Stream" ]]; then
         ost=1
     if [[ $VER == "8" ]]; then
         osv=1
+    elif [[ $VER == "9" ]]; then
+        osv=1
     else
         osv=2
     fi
 elif [[ $OS == "Rocky Linux" ]]; then
         ost=1
-    if [[ $VER =~ 8\. ]]; then
+    if [[ $VER =~ 8\. ]] || [[ $VER =~ 9\. ]]; then
+        osv=1
+    else
+        osv=2
+    fi
+elif [[ $OS == "AlmaLinux" ]]; then
+        ost=1
+    if [[ "$VERSION" =~ 8.* ]] || [[ "$VERSION" =~ 9.* ]]; then
         osv=1
     else
         osv=2


### PR DESCRIPTION
This is the updated version of the scripts I used to create a v4.2.1 mastodon image on Ubuntu 22.04. Most of these changes are either to bump up library versions, or to remove deprecated steps/scripts. The image check script was also updated.

There's currently an image built from these scripts sitting in DO. I did some basic testing and it seems to work from what I tried.